### PR TITLE
.github: add workflow to bump tags to head of master

### DIFF
--- a/.github/workflows/bump-tags.yaml
+++ b/.github/workflows/bump-tags.yaml
@@ -1,0 +1,30 @@
+name: Bump Tags on Master
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update v3 and v3.0.1 tags
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git tag -fa v3 -m "Update v3 tag to latest commit on master"
+          git tag -fa v3.0.1 -m "Update v3.0.1 tag to latest commit on master"
+          git push origin v3 v3.0.1 --force
+      - name: Send Slack notification on success
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": "Updated setup-rust v3 and v3.0.1 tags to the latest commit on master"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CACHE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GitHub Actions workflow to manually update `v3` and `v3.0.1` tags to the latest commit on master and notify via Slack.
> 
>   - **Workflow**:
>     - New workflow `bump-tags.yaml` added to update tags on master branch.
>     - Triggered manually using `workflow_dispatch`.
>   - **Jobs**:
>     - `bump-tags` job runs on `ubuntu-latest`.
>     - Checks out code with `fetch-depth: 0`.
>     - Updates `v3` and `v3.0.1` tags to latest commit on master and forces push to origin.
>   - **Notifications**:
>     - Sends Slack notification on successful tag update using `slackapi/slack-github-action@v1`.
>     - Uses `SLACK_WEBHOOK_URL` from secrets for notification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Frust-cache&utm_source=github&utm_medium=referral)<sup> for ce6f732b71068268bfb67007a7b44360340e43cc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->